### PR TITLE
Remove deprecated in_place arg to remove_small_objects

### DIFF
--- a/defdap/hrdic.py
+++ b/defdap/hrdic.py
@@ -536,8 +536,8 @@ class Map(base.Map):
         boundaries = boundaries > 0.1
 
         boundaries = mph.skeletonize(boundaries)
-        mph.remove_small_objects(boundaries, min_size=10, in_place=True,
-                                 connectivity=2)
+        mph.remove_small_objects(boundaries, min_size=10, connectivity=2,
+                                 out=boundaries)  # remove in-place
 
         # crop image if it is a simple affine transform
         if type(self.ebsdTransform) is tf.AffineTransform:

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'scipy',
         'numpy',
         'matplotlib>=3.0.0',
-        'scikit-image',
+        'scikit-image>=0.19',
         'pandas',
         'peakutils',
         'matplotlib_scalebar',


### PR DESCRIPTION
I was playing around with the develop branch and found that this code errored because I have the scikit-image main branch on my machine. 0.20 is going to be released in the next few days so now is a good time to make this change!