### PR TITLE
WIP: Optimise quaternion computations

### DIFF
--- a/defdap/quat.py
+++ b/defdap/quat.py
@@ -714,14 +714,10 @@ class Quat(object):
                 scalar_sym[:, np.newaxis] * scalar0
                 - np.tensordot(vector_sym, vector0, axes=[(1,), (0,)])
                 )[..., np.newaxis]
-        quat_comps_vector = (
-                scalar0[:, np.newaxis] * vector_sym[:, np.newaxis, :]
-                + scalar_sym[:, np.newaxis, np.newaxis] * vector0.T
-                + np.cross(
-                        vector_sym[:, np.newaxis, :], vector0.T,
-                        axisa=2, axisb=1,
-                        )
-                )
+        c0 = scalar0[:, np.newaxis] * vector_sym[:, np.newaxis, :]
+        c1 = scalar_sym[:, np.newaxis, np.newaxis] * vector0.T
+        c2 = np.cross(vector_sym[:, np.newaxis, :], vector0.T, axisa=2, axisb=1)
+        quat_comps_vector = c0 + c1 + c2
         quat_comps = np.concatenate(
                 [quat_comps_scalar, quat_comps_vector], axis=-1
                 )


### PR DESCRIPTION
Thanks @mikesmic for your guidance re quaternion product — that helped me understand the code in `calc_sym_eqvs` which is currently the slowest part of reading in a file. I've vectorised most of the operations and... See identical performance! 😅 So more work is needed. The other thing is that `extract_quat_comps` takes up ~50% of the runtime and that should be ~0 if the internal data structure was a NumPy array to begin with. The other target of optimisation is that operations like `np.cross` are more efficient when the coefficients are in certain axes... So I'll play with that too.