### PR TITLE
Improve masking

### DIFF
--- a/defdap/base.py
+++ b/defdap/base.py
@@ -118,6 +118,9 @@ class Map(ABC):
 
     def crop(self, map_data, **kwargs):
         return map_data
+    
+    def mask(self, map_data, **kwargs):
+        return map_data
 
     def set_homog_point(self, **kwargs):
         self.frame.set_homog_point(self, **kwargs)

--- a/defdap/base.py
+++ b/defdap/base.py
@@ -56,7 +56,7 @@ class Map(ABC):
 
         """
 
-        self.data = Datastore(crop_func=self.crop)
+        self.data = Datastore(crop_func=self.crop, mask_func=self.mask)
         self.frame = frame if frame is not None else Frame()
         if increment is not None:
             self.increment = increment

--- a/defdap/ebsd.py
+++ b/defdap/ebsd.py
@@ -73,7 +73,8 @@ class Map(base.Map):
             Nye_tensor : numpy.ndarray
                 3x3 Nye tensor at each point.
         Derived data:
-            Grain list data to map data from all grains
+            grain_data_to_map : numpy.ndarray
+                Grain list data to map data from all grains
 
     """
     MAPNAME = 'ebsd'
@@ -1156,9 +1157,9 @@ class Grain(base.Grain):
                 (x, y)
         Generated data:
             GROD : numpy.ndarray
-
+                Grain reference orientation distribution magnitude
             GROD_axis : numpy.ndarray
-
+                Grain reference orientation distribution direction
         Derived data:
             Map data to list data from the map the grain is part of
 

--- a/defdap/hrdic.py
+++ b/defdap/hrdic.py
@@ -484,7 +484,7 @@ class Map(base.Map):
         num_total = self.x_dim * self.y_dim
 
         print(
-            'Masking will remove {0} \ {1} ({2:.3f} %) datapoints in cropped map'
+            'Masking will remove {0} out of {1} ({2:.3f} %) datapoints in cropped map'
             .format(num_removed, num_total, (num_removed / num_total * 100)))
 
     def mask(self, map_data):

--- a/defdap/hrdic.py
+++ b/defdap/hrdic.py
@@ -484,7 +484,7 @@ class Map(base.Map):
         num_total = self.x_dim * self.y_dim
 
         print(
-            'Masking will remove {0} out of {1} ({2:.3f} %) datapoints in cropped map'
+            'Masking will mask {0} out of {1} ({2:.3f} %) datapoints in cropped map'
             .format(num_removed, num_total, (num_removed / num_total * 100)))
 
     def mask(self, map_data):

--- a/defdap/utils.py
+++ b/defdap/utils.py
@@ -99,6 +99,7 @@ class Datastore(object):
         '_derivatives',
         '_group_id',
         '_crop_func',
+        '_mask_func'
     ]
     _been_to = None
 
@@ -106,12 +107,13 @@ class Datastore(object):
     def generate_id():
         return uuid4()
 
-    def __init__(self, group_id=None, crop_func=None):
+    def __init__(self, group_id=None, crop_func=None, mask_func=None):
         self._store = {}
         self._generators = {}
         self._derivatives = []
         self._group_id = self.generate_id() if group_id is None else group_id
         self._crop_func = (lambda x, **kwargs: x) if crop_func is None else crop_func
+        self._mask_func = (lambda x, **kwargs: x) if mask_func is None else mask_func
 
     def __len__(self):
         """Number of data in the store, including data not yet generated."""
@@ -175,6 +177,8 @@ class Datastore(object):
                 not self.get_metadata(key, 'cropped', False)):
             binning = self.get_metadata(key, 'binning', 1)
             val = self._crop_func(val, binning=binning)
+            
+            val = self._mask_func(val)
 
         return val
 

--- a/defdap/utils.py
+++ b/defdap/utils.py
@@ -177,7 +177,6 @@ class Datastore(object):
                 not self.get_metadata(key, 'cropped', False)):
             binning = self.get_metadata(key, 'binning', 1)
             val = self._crop_func(val, binning=binning)
-            
             val = self._mask_func(val)
 
         return val

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'numba',
     ],
     extras_require={
-        'testing': ['pytest', 'coverage', 'pytest-cov', 'pytest_cases'],
+        'testing': ['pytest<8', 'coverage', 'pytest-cov', 'pytest_cases'],
         'docs': [
             'sphinx==5.0.2', 'sphinx_rtd_theme==0.5.0', 
             'sphinx_autodoc_typehints==1.11.1', 'nbsphinx==0.9.3', 


### PR DESCRIPTION
Masking is now performed on accessing data in the datastore.

Removed the preview function in `set_mask` since it is now extraneous as the original data is not being overwritten.

We should consider moving cropping and masking from `hrdic` into `base`