### PR TITLE
Fix #125

### DIFF
--- a/defdap/hrdic.py
+++ b/defdap/hrdic.py
@@ -938,8 +938,8 @@ class Map(base.Map):
                 # Find grain by masking the native ebsd grain image with
                 # selected grain from the warped dic grain image. The modal
                 # value is the EBSD grain label.
-                modeId, _ = mode(self.ebsdMap.grains[warpedDicGrains == i + 1])
-                ebsd_grain_idx = modeId[0] - 1
+                modeId, _ = mode(self.ebsdMap.grains[warpedDicGrains == i + 1], keepdims=False)
+                ebsd_grain_idx = modeId - 1
                 self.ebsdGrainIds.append(ebsd_grain_idx)
                 self[i].ebsdGrainId = ebsd_grain_idx
                 self[i].ebsdGrain = self.ebsdMap[ebsd_grain_idx]

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     package_data={'defdap': ['slip_systems/*.txt']},
     python_requires='>=3.6',
     install_requires=[
-        'scipy',
+        'scipy>=1.9',
         'numpy',
         'matplotlib>=3.0.0',
         'scikit-image',


### PR DESCRIPTION
In SciPy >1.11.0 the default value of keepdims is False which has broken the findGrains function.

I've opted to set keepdims to False and just take the scalar value instead of the first element of the array. Is this acceptable?