### PR TITLE
Fix labelling and position of HCP grains in IPF

### DIFF
--- a/defdap/__init__.py
+++ b/defdap/__init__.py
@@ -18,6 +18,7 @@ defaults = {
         'BCC': 'cubic_bcc',
         'HCP': 'hexagonal_withca',
     },
+    'ipf_triangle_convention': 'aztec'
 }
 
 anonymous_experiment = Experiment()

--- a/defdap/plotting.py
+++ b/defdap/plotting.py
@@ -1011,23 +1011,46 @@ class PolePlot(Plot):
                              pad_y=0.005, va='bottom', ha='center', fontsize=12)
 
         elif self.plot_type == "IPF" and self.crystal_sym == "hexagonal":
-            # line between [0001] and [10-10] ([001] and [210])
-            # converted to cubic axes
-            self.add_line([0, 0, 1], [np.sqrt(3), 1, 0], c='k', lw=2)
+            
+            triangle = 'aztec'
+            
+            if triangle == 'aztec':
+                # line between [0001] and [01-10] ([001] and [2-10])
+                # converted to cubic axes
+                self.add_line([0, 0, 1], [np.sqrt(3), -1, 0], c='k', lw=2)
 
-            # line between [0001] and [2-1-10] ([001] and [100])
-            self.add_line([0, 0, 1], [1, 0, 0], c='k', lw=2)
+                # line between [0001] and [-12-10] ([001] and [100])
+                self.add_line([0, 0, 1], [1, 0, 0], c='k', lw=2)
 
-            # line between [2-1-10] and [10-10] ([100] and [210])
-            self.add_line([1, 0, 0], [np.sqrt(3), 1, 0], c='k', lw=2)
+                # line between [-12-10] and [01-10] ([100] and [2-10])
+                self.add_line([1, 0, 0], [np.sqrt(3), -1, 0], c='k', lw=2)
 
-            # label poles
-            self.label_point([0, 0, 1], '0001',
-                             pad_y=-0.012, va='top', ha='center', fontsize=12)
-            self.label_point([1, 0, 0], r'$2\bar{1}\bar{1}0$',
-                             pad_y=-0.012, va='top', ha='center', fontsize=12)
-            self.label_point([np.sqrt(3), 1, 0], r'$10\bar{1}0$',
-                             pad_y=0.009, va='bottom', ha='center', fontsize=12)
+                # label poles
+                self.label_point([0, 0, 1], '0001',
+                                pad_y=0.012, va='bottom', ha='center', fontsize=12)
+                self.label_point([1, 0, 0], r'$\bar{1}2\bar{1}0$',
+                                pad_y=0.012, va='bottom', ha='center', fontsize=12)
+                self.label_point([np.sqrt(3), -1, 0], r'$01\bar{1}0$',
+                                pad_y=-0.006, va='top', ha='center', fontsize=12)
+            
+            elif triangle == 'mtex':
+                # line between [0001] and [10-10] ([001] and [210])
+                # converted to cubic axes
+                self.add_line([0, 0, 1], [np.sqrt(3), 1, 0], c='k', lw=2)
+
+                # line between [0001] and [2-1-10] ([001] and [100])
+                self.add_line([0, 0, 1], [1, 0, 0], c='k', lw=2)
+
+                # line between [2-1-10] and [10-10] ([100] and [210])
+                self.add_line([1, 0, 0], [np.sqrt(3), 1, 0], c='k', lw=2)
+
+                # label poles
+                self.label_point([0, 0, 1], '0001',
+                                pad_y=-0.012, va='top', ha='center', fontsize=12)
+                self.label_point([1, 0, 0], r'$2\bar{1}\bar{1}0$',
+                                pad_y=-0.012, va='top', ha='center', fontsize=12)
+                self.label_point([np.sqrt(3), 1, 0], r'$10\bar{1}0$',
+                                pad_y=0.009, va='bottom', ha='center', fontsize=12)
 
         else:
             raise NotImplementedError("Only works for cubic and hexagonal.")

--- a/defdap/plotting.py
+++ b/defdap/plotting.py
@@ -1012,7 +1012,7 @@ class PolePlot(Plot):
 
         elif self.plot_type == "IPF" and self.crystal_sym == "hexagonal":
             
-            triangle = 'aztec'
+            triangle = defaults['ipf_triangle_convention']
             
             if triangle == 'aztec':
                 # line between [0001] and [01-10] ([001] and [2-10])
@@ -1047,9 +1047,9 @@ class PolePlot(Plot):
                 # label poles
                 self.label_point([0, 0, 1], '0001',
                                 pad_y=-0.012, va='top', ha='center', fontsize=12)
-                self.label_point([1, 0, 0], r'$2\bar{1}\bar{1}0$',
+                self.label_point([1, 0, 0], r'$\bar{1}2\bar{1}0$',
                                 pad_y=-0.012, va='top', ha='center', fontsize=12)
-                self.label_point([np.sqrt(3), 1, 0], r'$10\bar{1}0$',
+                self.label_point([np.sqrt(3), 1, 0], r'$\bar{1}100$',
                                 pad_y=0.009, va='bottom', ha='center', fontsize=12)
 
         else:

--- a/defdap/quat.py
+++ b/defdap/quat.py
@@ -16,6 +16,7 @@
 import numpy as np
 
 from defdap import plotting
+from defdap import defaults
 
 from typing import Union, Tuple, List, Optional
 
@@ -1053,9 +1054,13 @@ class Quat(object):
 
         elif sym_group == "hexagonal":
             
-            triangle = 'aztec'
+            triangle = defaults['ipf_triangle_convention']
+            convention = defaults['crystal_ortho_conv']
+
+            if convention.lower() in ['hkl', 'oi']:
+                beta += np.pi / 6
             
-            if triangle == 'aztec':
+            if triangle.lower() == 'aztec':
                     
                 # first beta should be between 0 and 30 deg leaving 1
                 # symmetric equivalent per orientation
@@ -1067,7 +1072,7 @@ class Quat(object):
                     trial_poles = np.logical_and(beta >= delta_beta,
                                                 beta <= - (np.pi / 6 + delta_beta))
             
-            if triangle == 'mtex':
+            if triangle.lower() == 'mtex':
                 
                 # first beta should be between -30 and 0 deg leaving 1
                 # symmetric equivalent per orientation

--- a/defdap/quat.py
+++ b/defdap/quat.py
@@ -1052,15 +1052,32 @@ class Quat(object):
             alpha_fund = alpha[min_alpha_idx, np.arange(len(min_alpha_idx))]
 
         elif sym_group == "hexagonal":
-            # first beta should be between 0 and 30 deg leaving 1
-            # symmetric equivalent per orientation
-            trial_poles = np.logical_and(beta >= 0, beta <= np.pi / 6)
-            # if less than 1 left need to expand search slightly to
-            # catch edge cases
-            if np.any(np.sum(trial_poles, axis=0) < 1):
-                delta_beta = 1e-8
-                trial_poles = np.logical_and(beta >= -delta_beta,
-                                            beta <= np.pi / 6 + delta_beta)
+            
+            triangle = 'aztec'
+            
+            if triangle == 'aztec':
+                    
+                # first beta should be between 0 and 30 deg leaving 1
+                # symmetric equivalent per orientation
+                trial_poles = np.logical_and(beta <= 0, beta >= -np.pi / 6)
+                # if less than 1 left need to expand search slightly to
+                # catch edge cases
+                if np.any(np.sum(trial_poles, axis=0) < 1):
+                    delta_beta = 1e-8
+                    trial_poles = np.logical_and(beta >= delta_beta,
+                                                beta <= - (np.pi / 6 + delta_beta))
+            
+            if triangle == 'mtex':
+                
+                # first beta should be between -30 and 0 deg leaving 1
+                # symmetric equivalent per orientation
+                trial_poles = np.logical_and(beta >= 0, beta <= np.pi / 6)
+                # if less than 1 left need to expand search slightly to
+                # catch edge cases
+                if np.any(np.sum(trial_poles, axis=0) < 1):
+                    delta_beta = 1e-8
+                    trial_poles = np.logical_and(beta >= -delta_beta,
+                                                beta <= np.pi / 6 + delta_beta)
 
             # non-indexed points cause more than 1 symmetric equivalent, use this
             # to pick one and filter non-indexed points later


### PR DESCRIPTION
HCP orientations are now plotted onto the IPF in the correct place. There is an option to choose between triangle facing down (like aztec) and triangle facing up (like mtex).